### PR TITLE
translated: what-is-the-ic/6_references/index.md

### DIFF
--- a/what-is-the-ic/6_references/index.md
+++ b/what-is-the-ic/6_references/index.md
@@ -1,4 +1,16 @@
 ---
+title: リファレンスと詳細情報
+card: /img/what-is-the-ic/features.jpg
+cardImageFit: cover
+---
+
+- すべての IC コンポーネントがどのように機能し、組み合わされているかをより深く理解するための適当なリソースは、 [How it Works](/how-it-works/) ページと [ホワイトペーパー](https://internetcomputer.org/whitepaper.pdf)です。
+- IC のすべてのソースコードは、[IC レポジトリ](https://github.com/dfinity/ic) で公開されています。
+- IC のサブネット、ノード、ノードプロバイダ、Canister、NNS プロポーザル、投票、ICP トランザクションなどの情報は、[ダッシュボード](https://dashboard.internetcomputer.org/)で見ることができます。
+- Motoko は、IC 上のスマートコントラクトに特化した画期的なプログラミング言語です。[Motoko](https://github.com/dfinity/motoko) をチェックしてください。
+
+<!--
+---
 title: References and further information
 card: /img/what-is-the-ic/features.jpg
 cardImageFit: cover
@@ -8,3 +20,4 @@ cardImageFit: cover
 - All of the IC's source code is available in [the IC repo](https://github.com/dfinity/ic).
 - You can find information on the IC's subnets, nodes, node providers, canisters, NNS proposals, voting, ICP transactions and more on our [dashboard](https://dashboard.internetcomputer.org/).
 - Motoko is a novel programming language tailored to smart contracts on the IC. Check out [Motoko](https://github.com/dfinity/motoko).
+-->

--- a/what-is-the-ic/6_references/index.md
+++ b/what-is-the-ic/6_references/index.md
@@ -5,7 +5,7 @@ cardImageFit: cover
 ---
 
 - すべての IC コンポーネントがどのように機能し、組み合わされているかをより深く理解するための適当なリソースは、 [How it Works](/how-it-works/) ページと [ホワイトペーパー](https://internetcomputer.org/whitepaper.pdf)です。
-- IC のすべてのソースコードは、[IC レポジトリ](https://github.com/dfinity/ic) で公開されています。
+- IC のすべてのソースコードは、[IC リポジトリ](https://github.com/dfinity/ic) で公開されています。
 - IC のサブネット、ノード、ノードプロバイダ、Canister、NNS プロポーザル、投票、ICP トランザクションなどの情報は、[ダッシュボード](https://dashboard.internetcomputer.org/)で見ることができます。
 - Motoko は、IC 上のスマートコントラクトに特化した画期的なプログラミング言語です。[Motoko](https://github.com/dfinity/motoko) をチェックしてください。
 


### PR DESCRIPTION
### 相談したいところ

リンクの"How it works"がURLのパス名になっているのですが、リンクに飛んでも、"How it works"とタイトル名になっていないので原文のままにしました。なにか見落としているかも知れません。
